### PR TITLE
Disable bullet points when numbered list

### DIFF
--- a/_sass/components/_chapter.scss
+++ b/_sass/components/_chapter.scss
@@ -90,6 +90,13 @@
       font-style: italic;
     }
 
+    ol {
+      
+      li::before {
+        content: none;
+      }
+    }
+
     ul {
       margin: 0;
       margin-bottom: $base-sizing;


### PR DESCRIPTION
Get rid of the bullet points when numbered list available. Example: ![alt image](https://monosnap.com/file/IUYkhrYYQPCBk6fW8klorvqzAqYicV.png "list")
